### PR TITLE
v1.0.0-Beta17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         if: env.SNAPSHOT == 'false'
         run: |
           gradle publish --no-daemon --no-parallel
-          gradle publishToSonatype closeAndReleaseSonatypeStagingRepository
+          gradle publishAllPublicationsToCentralPortal
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY: ${{ secrets.GPG_KEY }}

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta16] - 2024-09-27
+
 ## [1.0.0-beta15] - 2024-09-20
 
 ## [1.0.0-beta14] - 2024-09-13
@@ -43,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.0.0-beta15...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.0.0-beta16...HEAD
+
+[1.0.0-beta16]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.0.0-beta15...v1.0.0-beta16
 
 [1.0.0-beta15]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.0.0-beta14...v1.0.0-beta15
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Sep 20 13:03:11 UTC 2024
-boxlangVersion=1.0.0-beta16
+#Fri Sep 27 21:33:08 UTC 2024
+boxlangVersion=1.0.0-beta17
 jdkVersion=21
-version=1.0.0-beta16
+version=1.0.0-beta17
 group=com.ortussolutions


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta17

### Bug

[BL-608](https://ortussolutions.atlassian.net/browse/BL-608) Timeouts \(connection, idle\) for datasources needs to be in seconds and not in milliseconds to adhere to cfconfig

[BL-609](https://ortussolutions.atlassian.net/browse/BL-609) BoxLang resolvers do not allow class paths to have \`-\` in them.

### Improvement

[BL-607](https://ortussolutions.atlassian.net/browse/BL-607) Add version/build date to output of Miniserver startup

[BL-610](https://ortussolutions.atlassian.net/browse/BL-610) onSessionEnd needs application settings made available

[BL-611](https://ortussolutions.atlassian.net/browse/BL-611) Remove debugmode capture on miniserver, delegate to the core runtime.

### New Feature

[BL-605](https://ortussolutions.atlassian.net/browse/BL-605) MiniServer WebSocket handler

[BL-608]: https://ortussolutions.atlassian.net/browse/BL-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-609]: https://ortussolutions.atlassian.net/browse/BL-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-607]: https://ortussolutions.atlassian.net/browse/BL-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-610]: https://ortussolutions.atlassian.net/browse/BL-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-611]: https://ortussolutions.atlassian.net/browse/BL-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-605]: https://ortussolutions.atlassian.net/browse/BL-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ