### PR TITLE
v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ env:
   MODULE_ID: ${{ github.event.repository.name }}
   SNAPSHOT: ${{ inputs.snapshot || false }}
   JDK: 21
-  GRADLE: 8.7
   BUILD_ID: ${{ github.run_number }}
   LTS: ${{ inputs.lts || false }}
   MAVEN_PUBLISH: ${{ inputs.maven_publish || true }}
@@ -66,11 +65,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ env.JDK }}
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: ${{ env.GRADLE }}
 
       - name: Setup Environment Variables For Build Process
         id: current_version
@@ -103,8 +97,8 @@ jobs:
         run: |
           npm install -g markdownlint-cli
           markdownlint changelog.md --fix
-          gradle downloadBoxLang
-          gradle build -x test --stacktrace --console=plain
+          ./gradlew downloadBoxLang
+          ./gradlew build -x test --stacktrace --console=plain
 
       - name: Commit Changelog [unreleased] with latest version
         uses: EndBug/add-and-commit@v9.1.4
@@ -169,7 +163,7 @@ jobs:
       - name: Publish to Github Packages
         if: env.SNAPSHOT == 'false'
         run: |
-          gradle publish --no-daemon --no-parallel --info
+          ./gradlew publish --no-daemon --no-parallel --info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY: ${{ secrets.GPG_KEY }}
@@ -179,7 +173,7 @@ jobs:
       - name: Publish to Maven Central
         if: env.SNAPSHOT == 'false' && env.MAVEN_PUBLISH == 'true'
         run: |
-          gradle publishAllPublicationsToCentralPortal --stacktrace --info
+          ./gradlew publishAllPublicationsToCentralPortal --stacktrace --info
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
@@ -236,11 +230,6 @@ jobs:
         with:
           name: boxlang-build
           path: .tmp
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: ${{ env.GRADLE }}
 
       - name: Copy Changelog
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,23 @@ shadowJar {
 build.finalizedBy( shadowJar )
 
 /**
+ * Generate checksums for the given file using the specified algorithm
+
+ * @param file The file to generate the checksum for
+ * @param algorithm The algorithm to use (e.g., "SHA-256", "MD5")
+ */
+def generateChecksum( File file, String algorithm ) {
+	def digest = java.security.MessageDigest.getInstance( algorithm )
+	file.eachByte( 4096 ) { bytes, size ->
+		digest.update( bytes, 0, size )
+	}
+	def checksum = digest.digest().collect { String.format( '%02x', it ) }.join()
+
+	def checksumFile = new File( file.parent, "${file.name}.${algorithm.toLowerCase()}" )
+	checksumFile.text = "${checksum}  ${file.name}\n"
+}
+
+/**
  * Publish the artifacts to the local maven repository
  */
 publishing {
@@ -322,11 +339,24 @@ task buildMainZip( type: Zip ) {
 	}
 
 	doLast {
+		// Generate checksums for all zip and jar files in distributions folder
+		file( "build/distributions" ).listFiles().each { file ->
+			if ( file.name.endsWith( '.zip' ) || file.name.endsWith( '.jar' ) ) {
+				generateChecksum( file, 'SHA-256' )
+				generateChecksum( file, 'MD5' )
+			}
+		}
+
 		file( "build/evergreen" ).mkdirs()
 		if( branch == 'development' ){
 			Files.copy( file( "build/distributions/boxlang-aws-lambda-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-aws-lambda-snapshot.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			// Checksums
+			Files.copy( file( "build/distributions/boxlang-aws-lambda-${version}.jar.sha-256" ).toPath(), file( "build/evergreen/boxlang-aws-lambda-snapshot.jar.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-aws-lambda-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-aws-lambda-snapshot.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
 		} else {
 			Files.copy( file( "build/distributions/boxlang-aws-lambda-${version}.jar" ).toPath(), file( "build/evergreen/boxlang-aws-lambda-latest.jar" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-aws-lambda-${version}.jar.sha-256" ).toPath(), file( "build/evergreen/boxlang-aws-lambda-latest.jar.sha-256" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
+			Files.copy( file( "build/distributions/boxlang-aws-lambda-${version}.jar.md5" ).toPath(), file( "build/evergreen/boxlang-aws-lambda-latest.jar.md5" ).toPath(), StandardCopyOption.REPLACE_EXISTING )
 		}
 
 		println "+ Main Zip has been created"

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-05-29
+
 ## [1.1.0] - 2025-05-12
 
 ### New Features
@@ -43,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2025-04-30
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.2.0...HEAD
+
+[1.2.0]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.1.0...v1.2.0
 
 [1.1.0]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.0.0...v1.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Mon May 12 20:56:58 UTC 2025
-boxlangVersion=1.2.0
+#Thu May 29 15:31:39 UTC 2025
+boxlangVersion=1.3.0
 jdkVersion=21
-version=1.2.0
+version=1.3.0
 group=ortus.boxlang


### PR DESCRIPTION
Release Notes
New Feature
[BL-1508](https://ortussolutions.atlassian.net/browse/BL-1508) Add `compressionLevel` to the zip component and utilities
[BL-1512](https://ortussolutions.atlassian.net/browse/BL-1512) Add checksums to all binary creations in the build process
[BL-1533](https://ortussolutions.atlassian.net/browse/BL-1533) xNone() for bif operations: array, list, query, struct
[BL-1542](https://ortussolutions.atlassian.net/browse/BL-1542) Added `pretty` argument to jsonSerialize() to allow for pretty serialization
Improvement
[BL-1471](https://ortussolutions.atlassian.net/browse/BL-1471) Add Examples to docs for BIFs and Components
[BL-1494](https://ortussolutions.atlassian.net/browse/BL-1494) Don't allow scopes to be "overridden" with scope hunting
[BL-1511](https://ortussolutions.atlassian.net/browse/BL-1511) Add Support for Compressed HTTP responses
[BL-1516](https://ortussolutions.atlassian.net/browse/BL-1516) arrayFind shouldn't throw on mismatched types
[BL-1519](https://ortussolutions.atlassian.net/browse/BL-1519) Small update to make sure only runtime dependencies are stored in the `lib` folder using our maven pom in the Boxlang home.
[BL-1521](https://ortussolutions.atlassian.net/browse/BL-1521) Add --help -h to Mini Server
[BL-1522](https://ortussolutions.atlassian.net/browse/BL-1522) Add --help -h to Feature Audit, CFTranspiler, Scheduler, BoxRunner and more
[BL-1526](https://ortussolutions.atlassian.net/browse/BL-1526) Bumps org.semver4j:semver4j from 5.7.0 to 5.7.1.
[BL-1528](https://ortussolutions.atlassian.net/browse/BL-1528) Add lazy expiration for caching
[BL-1534](https://ortussolutions.atlassian.net/browse/BL-1534) Query Concurrency Improvements : There are some inconsistencies and issues when dealing with adding data to queries in parallel threads
[BL-1536](https://ortussolutions.atlassian.net/browse/BL-1536) Bumps com.fasterxml.jackson.jr:jackson-jr-stree from 2.19.0 to 2.19.1.
[BL-1537](https://ortussolutions.atlassian.net/browse/BL-1537) Refactor @NonNull and @Nullable to use compile time checkers instead of runtime dependencies
[BL-1544](https://ortussolutions.atlassian.net/browse/BL-1544) Create a transpiler rule for cfquery params: `cfsqltype` to `sqltype`
Bugs
[BL-1216](https://ortussolutions.atlassian.net/browse/BL-1216) Image scaleToFit creating black images
[BL-1217](https://ortussolutions.atlassian.net/browse/BL-1217) Image resize not working as member func.
[BL-1472](https://ortussolutions.atlassian.net/browse/BL-1472) JDBC - Transaction defaults to app-default datasource, and ignores the datasource named in the first query
[BL-1501](https://ortussolutions.atlassian.net/browse/BL-1501) Compat: Math Operations Which Encounter Timestamps Should Cast as Fractional Days
[BL-1503](https://ortussolutions.atlassian.net/browse/BL-1503) Update parallel computations to use a tiered execution approach; xSome, xEvery, xMap, xFilter, xEach
[BL-1504](https://ortussolutions.atlassian.net/browse/BL-1504) looping groups breaks when it should continue
[BL-1507](https://ortussolutions.atlassian.net/browse/BL-1507) HTTP Errors When Uploading File
[BL-1513](https://ortussolutions.atlassian.net/browse/BL-1513) fix() behaviour is not equal to Lucee's behaviour
[BL-1523](https://ortussolutions.atlassian.net/browse/BL-1523) All multi-part form fields are being written to disk
[BL-1524](https://ortussolutions.atlassian.net/browse/BL-1524) CFCatch support when catch variable defined in bx-compat-cfml
[BL-1527](https://ortussolutions.atlassian.net/browse/BL-1527) DATETIME is not being aliased by query parameters in prepared statements
[BL-1529](https://ortussolutions.atlassian.net/browse/BL-1529) Several concurrency issues on cache entries created and last access timeouts
[BL-1530](https://ortussolutions.atlassian.net/browse/BL-1530) cache entry equals evaluating the hash codes incorrectly and causing collisions
[BL-1531](https://ortussolutions.atlassian.net/browse/BL-1531) Set base template for remote methods in super class
[BL-1532](https://ortussolutions.atlassian.net/browse/BL-1532) Better handle ../ in servlet paths
[BL-1541](https://ortussolutions.atlassian.net/browse/BL-1541) The `type` property in class metadata still references "component" instead of being "class"
[BL-1547](https://ortussolutions.atlassian.net/browse/BL-1547) duplicate function broken when using xml objects