### PR TITLE
Version bump

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-07-08
+
 ## [1.14.0] - 2026-06-03
 
 ## [1.13.0] - 2026-05-01
@@ -81,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * * *
 
-[unreleased]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.14.0...HEAD
+[unreleased]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/ortus-boxlang/boxlang-aws-lambda/compare/v1.11.0...v1.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Wed Jun 03 09:48:27 UTC 2026
-boxlangVersion=1.15.0
+#Wed Jul 08 21:16:19 UTC 2026
+boxlangVersion=1.16.0
 jdkVersion=21
-version=1.15.0
+version=1.16.0
 group=ortus.boxlang


### PR DESCRIPTION
This pull request updates the project version to `1.16.0` in preparation for the next release. It also adds release notes and comparison links for the previous `1.15.0` release in the changelog.

Version and release management:

* Updated `gradle.properties` to set `boxlangVersion` and `version` to `1.16.0`, indicating the start of development for the next release.
* Added a new section for version `1.15.0` in `changelog.md` and updated the comparison links to include `1.15.0`. [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R12-R13) [[2]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3L84-R87)